### PR TITLE
Fix test for a corner case

### DIFF
--- a/test.js
+++ b/test.js
@@ -86,9 +86,11 @@ describe('Duplex Child Process', function () {
     .spawn('identify', ['-format', '%m', '-'])
     .on('error', done)
     .on('readable', function () {
-      assert.equal('PNG', this.read().toString('utf8').trim())
-
-      done()
+      var data = this.read()
+      if (data) {
+        assert.equal('PNG', data.toString('utf8').trim())
+        done()
+      }
     })
   })
 })


### PR DESCRIPTION
readable was called twice on my setup (node 0.11.9), this.read() was null the second time which is allowed according to node documentation (If there is no data available, then it will return null.)
