### PR TITLE
handle ECONNRESET upon early stdin end

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,8 +68,9 @@ Child_Process.prototype.spawn = function (command, args, options) {
   this._stderr.on('data', onStderrData)
   
   // In some cases ECONNRESET can be emitted by stdin because the process is not interested in any
-  // more data but the _writer is still piping. This should not trigger an error.
+  // more data but the _writer is still piping. Forget about errors emitted on stdin and stdout
   this._stdin.on('error', noop)
+  this._stdout.on('error', noop)
   
   this._process.once('close', onExit)
   this._process.once('error', onError)


### PR DESCRIPTION
I tracked down an error I have with 'identity' in a specific scenario but I am sure I can happen in other cases when the spawned process decides that it does not want any more data on stdin.

my bug came from a specific identify setup, with a png image available a a buffer in memory, and telling identify we already know it is a png image (`png:-`)

here is a test that throws the ECONNRESET from time to time (once every 10 `make test` I would say)

```
it('should accept early child.stdin termination', function (done) {
    var buffer = fs.readFileSync(image_png);
    var child = new Child_Process();
    child.end(buffer);
    child
    .spawn('identify', ['-format', '%m', 'PNG:-'])
    .on('error', done)
    .on('readable', function () {
      var data = this.read();
      if (data) {
        assert.equal('PNG', data.toString('utf8').trim())
        done()
      }
    })
  })
```

note that I tried to do a 

```
this._stdin.once('finish', function() { that._writer.unpipe(that._stdin); });
```

but that did not work. The ECONNRESET probably comes because identify does something to the stdin socket before node calls the finish event.

Tell me if this makes sense to you.

At this stage I am intercepting the error in my code but I would prefer not having to reference `_stdin.on(..)` outside of duplex-child-process.
