### PR TITLE
Run Travis CI on current node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 node_js:
-- "0.10"
+- "6"
+- "8"
+- "10"
 language: node_js
 before_install:
 - sudo apt-get update
 - sudo apt-get install imagemagick
+sudo: true


### PR DESCRIPTION
PR to run tests on Travis CI on current versions of Node (6, 8, 10).