### PR TITLE
Fixed issue with stream closing prematurely

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,8 +87,7 @@ Child_Process.prototype.spawn = function (command, args, options) {
   function onStdoutEnd() {
     if (exited && !ended) {
       ended = true;
-      that._reader.end();
-      setImmediate(that.emit.bind(that, 'close'))
+      that._reader.end(that.emit.bind(that, 'close'));
     }
   }
 


### PR DESCRIPTION
We encountered some issues where the target-stream of the duplex-child-process would wait indefinitely for the duplex-child-process to finish.
Some debugging info showed that the `readable` stream in duplex-child-process was in an odd state with values like these: `needsDrain: true, awaitDrain: 1, flowing: false`.

Some more debugging showed that the duplex stream does not wait for the end-event of the readable stream to be fully processed before closing. Using the callback of the `end()` function solved the issue.
